### PR TITLE
fix: use java compiler before executing java code

### DIFF
--- a/src/run-code/instructions.js
+++ b/src/run-code/instructions.js
@@ -4,9 +4,13 @@ const commandMap = (jobID, language) => {
     switch (language) {
         case 'java':
             return {
+                compileCodeCommand: 'javac',
+                compilationArgs: [
+                    join(process.cwd(), `codes/${jobID}.java`)
+                ],
                 executeCodeCommand: 'java',
                 executionArgs: [
-                    join(process.cwd(), `codes/${jobID}.java`)
+                    join(process.cwd(), `codes/${jobID}`)
                 ],
                 compilerInfoCommand: 'java --version'
             };


### PR DESCRIPTION
Previously we were directly running `java codes/file-name.java` to execute java code which led to the following issue #49, now it will use the javac compiler before executing so that all the classes in the file are included during execution.

Closes: #49