### PR TITLE
Updating Running Port on Docker Run Command (8080) instead of (3000)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -7,5 +7,5 @@ In order to setup this project locally on your machine, you can either run the d
 ```bash
 docker build --no-cache -t codex-api .
 
-docker run -p 3000:3000 codex-api
+docker run -p 8080:8080 codex-api
 ```


### PR DESCRIPTION
in Dockerfile, you're exposing and 8080 and running the server on 3000 which is wrong
this pull request updates the setup documentation of running this API in locally "self host"